### PR TITLE
update autobahn

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "webpack-dev-server": "1.16.2"
   },
   "dependencies": {
-    "autobahn": "0.12.0",
+    "autobahn": "17.5.1",
     "bluebird": "3.5.0",
     "bluebird-retry": "0.10.1",
     "chokidar": "1.6.1",


### PR DESCRIPTION
closes #37 
this update autbah, which has `google-closure-compiler` as devDep: crossbario/autobahn-js/pull/295
win npm installation still throws errors about `bufferutil` and `utf-8-validate`, but as it is optional deps installation goes well.