### PR TITLE
Use strict TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,3 @@ before_script:
 
 cache:
   yarn: true
-  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,4 +22,3 @@ build: off
 
 cache:
  - "%LOCALAPPDATA%\\Yarn"
- 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,19 @@
     "url": "https://github.com/wix/kissfs/issues"
   },
   "homepage": "https://github.com/wix/kissfs#readme",
+  "dependencies": {
+    "autobahn": "^17.5.2",
+    "bluebird": "^3.5.0",
+    "bluebird-retry": "^0.11.0",
+    "chokidar": "^1.7.0",
+    "eventemitter3": "^2.0.3",
+    "fs-extra": "^4.0.2",
+    "is-glob": "^4.0.0",
+    "klaw": "^2.1.0",
+    "lodash": "^4.17.4",
+    "micromatch": "^2.3.11",
+    "wamp-server": "^0.0.6"
+  },
   "devDependencies": {
     "@types/autobahn": "^0.9.37",
     "@types/bluebird": "^3.5.12",
@@ -67,19 +80,6 @@
     "typescript": "~2.5.2",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.8.2"
-  },
-  "dependencies": {
-    "autobahn": "^17.5.2",
-    "bluebird": "^3.5.0",
-    "bluebird-retry": "^0.11.0",
-    "chokidar": "^1.7.0",
-    "eventemitter3": "^2.0.3",
-    "fs-extra": "^4.0.2",
-    "is-glob": "^4.0.0",
-    "klaw": "^2.1.0",
-    "lodash": "^4.17.4",
-    "micromatch": "^2.3.11",
-    "wamp-server": "^0.0.6"
   },
   "optionalDependencies": {
     "bufferutil": "^1.0.0",

--- a/src/cache-fs.ts
+++ b/src/cache-fs.ts
@@ -6,7 +6,6 @@ import {
     File,
     isDir,
     isFile,
-    fileSystemMethods,
     UnexpectedErrorEvent,
     isDisposable, ShallowDirectory
 } from './api';
@@ -27,7 +26,7 @@ interface TreesDiff {
     toChange: string[]
 }
 
-function nodesToMap(tree: FileSystemNode[], accumulator = {}): FileSystemNodesMap {
+function nodesToMap(tree: FileSystemNode[], accumulator: FileSystemNodesMap = {}): FileSystemNodesMap {
     tree.forEach(node => {
         if (isDir(node)) nodesToMap(node.children, accumulator);
         accumulator[node.fullPath] = node;
@@ -149,7 +148,7 @@ export class CacheFileSystem implements FileSystem {
             .then(() => this.cache.ensureDirectory(fullPath));
     }
 
-    loadTextFile(fullPath): Promise<string> {
+    loadTextFile(fullPath: string): Promise<string> {
         if (this.pathsInCache[fullPath]) return this.cache.loadTextFile(fullPath)
         return this.fs.loadTextFile(fullPath)
             .then(file => {
@@ -224,7 +223,7 @@ export class CacheFileSystem implements FileSystem {
         })
     }
 
-    private emit(type, data) {
+    private emit(type: string, data: object) {
         this.events.emit(type, {...data, type});
     }
 

--- a/src/local-fs.ts
+++ b/src/local-fs.ts
@@ -2,7 +2,6 @@ import * as Promise from 'bluebird';
 import * as retry from 'bluebird-retry';
 import {watch} from 'chokidar';
 import * as path from 'path';
-import {Stats} from 'fs';
 import {FSWatcher} from 'chokidar';
 import {FileSystem, pathSeparator} from "./api";
 import {LocalFileSystemCrudOnly} from './local-fs-crud-only';
@@ -11,7 +10,7 @@ export class LocalFileSystem extends LocalFileSystemCrudOnly implements FileSyst
     private watcher: FSWatcher;
 
     constructor(
-        public baseUrl,
+        public baseUrl: string,
         ignore?: Array<string>,
         private retrySettings: retry.Options = {
             interval: 100,
@@ -24,7 +23,7 @@ export class LocalFileSystem extends LocalFileSystemCrudOnly implements FileSyst
         this.watcher = watch([this.baseUrl], {
             //  usePolling:true,
             //  interval:100,
-            ignored: path => this.isIgnored(path),
+            ignored: (path: string) => this.isIgnored(path),
             //    atomic: false, //todo 50?
             cwd: this.baseUrl
         });
@@ -34,7 +33,7 @@ export class LocalFileSystem extends LocalFileSystemCrudOnly implements FileSyst
         return new Promise<LocalFileSystem>(resolve => {
             this.watcher.once('ready', () => {
 
-                this.watcher.on('addDir', (relPath:string, stats:Stats)=> {
+                this.watcher.on('addDir', (relPath:string)=> {
                         if (relPath) { // ignore event of root folder creation
                             this.events.emit('directoryCreated', {
                                 type: 'directoryCreated',

--- a/src/timeout-fs.ts
+++ b/src/timeout-fs.ts
@@ -3,8 +3,6 @@ import {
     FileSystem,
     Directory,
     EventEmitter,
-    pathSeparator,
-    FileSystemNode,
     isDisposable, ShallowDirectory
 } from './api';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import {EventEmitter} from 'eventemitter3';
-import * as isGlob from 'is-glob';
 import * as micromatch from 'micromatch';
+const isGlob = require('is-glob');
+
 import {pathSeparator, EventEmitter as FSEvents} from './api';
 
 // utility logic for filesystem implementations

--- a/src/wamp-client-fs.ts
+++ b/src/wamp-client-fs.ts
@@ -10,12 +10,10 @@ export class WampClientFileSystem implements FileSystem {
     private connection: Connection;
     private session: Session;
     private realmPrefix: string;
-    public baseUrl: string;
 
-    constructor(url, private realm: string, private initTimeout: number = 5000) {
-        this.baseUrl = url;
+    constructor(public baseUrl: string, private realm: string, private initTimeout: number = 5000) {
         this.realm = realm;
-        this.connection = new Connection({url, realm});
+        this.connection = new Connection({url: baseUrl, realm});
     }
 
     init(): Promise<WampClientFileSystem> {
@@ -86,7 +84,7 @@ export class WampClientFileSystem implements FileSystem {
         });
     }
 
-    loadTextFile(fullPath): Promise<string> {
+    loadTextFile(fullPath: string): Promise<string> {
         return new Promise<string>((resolve, reject) => {
             if (!this.session || !this.session.isOpen) {
                 return reject(noConnectionError);

--- a/src/wamp-server-over-fs.ts
+++ b/src/wamp-server-over-fs.ts
@@ -31,7 +31,7 @@ export function wampServerOverFs(fs: FileSystem, port = 3000): Promise<WampServe
             });
 
             fileSystemMethods.forEach(ev => {
-                session.register(`${wampRealmPrefix}${ev}`, (data: string[]) => fs[ev](...data).then(res => res));
+                session.register(`${wampRealmPrefix}${ev}`, (data: string[]) => (fs as any)[ev](...data));
             });
 
             resolve({
@@ -40,7 +40,7 @@ export function wampServerOverFs(fs: FileSystem, port = 3000): Promise<WampServe
             });
         };
 
-        connection.onclose = (reason, details) => {
+        connection.onclose = (_reason, details) => {
             if (!details.will_retry && isDisposable(fs)) {
                 fs.dispose();
             }

--- a/test-kit/drivers/slow-fs.ts
+++ b/test-kit/drivers/slow-fs.ts
@@ -3,13 +3,11 @@ import {
     FileSystem,
     Directory,
     File,
-    isDir,
-    fileSystemMethods,
     isDisposable, ShallowDirectory
 } from "../../src/api";
 
 import {MemoryFileSystem} from "../../src/memory-fs";
-import {InternalEventsEmitter, makeEventsEmitter} from "../../src/utils";
+import {InternalEventsEmitter} from "../../src/utils";
 import {ignoredDir, ignoredFile} from "../../test/implementation-suite";
 
 export class SlowFs implements FileSystem {

--- a/test-kit/test/events-matcher.spec.ts
+++ b/test-kit/test/events-matcher.spec.ts
@@ -39,7 +39,7 @@ describe('events test driver', ()=>{
         emitter.emit('event', {type:'event', foo:'bar'});
         var rejection = matcher.expect([{type:'event', foo:'baz'}]).catch(e => e);
         return expect(rejection).to.eventually.satisfy(
-            err => expect(err).to.containSubset({actual:[{foo:'bar'}], expected:[{foo:'baz'}]}));
+            (err: object) => expect(err).to.containSubset({actual:[{foo:'bar'}], expected:[{foo:'baz'}]}));
     });
 
     it('failure when mismatched events', () => {

--- a/test/cache-fs.spec.ts
+++ b/test/cache-fs.spec.ts
@@ -37,7 +37,6 @@ describe(`the cache file system implementation`, () => {
     describe(`using slow FileSystem`, () => {
         const timeout = 200;
 
-        let timer;
         let fs: FileSystem;
         let slow: FileSystem;
         let startTimestamp: number;
@@ -59,7 +58,7 @@ describe(`the cache file system implementation`, () => {
         })
 
         it('loads file faster after it has been saved from outside', () => {
-            const onFileCreated = new Promise((resolve, reject) => {
+            const onFileCreated = new Promise(resolve => {
                     fs.events.once('fileCreated', () => {
                         fs.loadTextFile(fileName)
                             .then(() => resolve(Date.now() - startTimestamp))

--- a/test/local-fs.spec.ts
+++ b/test/local-fs.spec.ts
@@ -51,7 +51,8 @@ describe(`the local filesystem implementation`, () => {
         }
     });
     afterEach(() =>{
-        disposableFileSystem.dispose();
+        // if beforeEach fails, disposableFileSystem can stay undefined
+        disposableFileSystem && disposableFileSystem.dispose();
     });
     function getFS() {
         testPath = join(rootPath, 'fs_'+(counter++));

--- a/test/local-fs.spec.ts
+++ b/test/local-fs.spec.ts
@@ -25,19 +25,18 @@ import {EventsMatcher} from '../test-kit/drivers/events-matcher';
 
 import {
     FileSystem,
-    pathSeparator,
     fileSystemEventNames
 } from '../src/universal';
 
 import {LocalFileSystem} from '../src/nodejs';
 
 describe(`the local filesystem implementation`, () => {
-    let dirCleanup, rootPath, testPath;
+    let dirCleanup: () => void, rootPath: string, testPath : string;
     let counter = 0;
-    let disposableFileSystem;
+    let disposableFileSystem: LocalFileSystem;
 
     before(done => {
-        dir({unsafeCleanup:true}, (err, path, cleanupCallback) => {
+        dir({unsafeCleanup:true}, (_err, path, cleanupCallback) => {
             dirCleanup = cleanupCallback;
             rootPath = path;
             done();
@@ -52,9 +51,7 @@ describe(`the local filesystem implementation`, () => {
         }
     });
     afterEach(() =>{
-        if (disposableFileSystem) {
-            disposableFileSystem.dispose();
-        }
+        disposableFileSystem.dispose();
     });
     function getFS() {
         testPath = join(rootPath, 'fs_'+(counter++));
@@ -179,16 +176,15 @@ describe(`the local filesystem implementation`, () => {
         });
 
         it(`emits 'unexpectedError' if 'loadTextFile' rejected in watcher 'add' callback`, () => {
-            fs.loadTextFile = path => Promise.reject('go away!');
+            fs.loadTextFile = () => Promise.reject('go away!');
             const path = join(testPath, fileName);
             writeFileSync(path, content);
             return matcher.expect([{type: 'unexpectedError'}]);
         });
 
         it(`emits 'unexpectedError' if 'loadTextFile' rejected in watcher 'change' callback`, () => {
-            const path = join(testPath, fileName);
             return fs.saveFile(fileName, content)
-                .then(() => fs.loadTextFile = path => Promise.reject('go away!'))
+                .then(() => fs.loadTextFile = () => Promise.reject('go away!'))
                 .then(() => fs.saveFile(fileName, `_${content}`))
                 .then(() => matcher.expect([{type: 'unexpectedError'}]))
         });

--- a/test/memory-fs.spec.ts
+++ b/test/memory-fs.spec.ts
@@ -1,7 +1,6 @@
 import * as Promise from 'bluebird';
-import {expect} from 'chai';
 import {assertFileSystemContract, ignoredDir, ignoredFile} from './implementation-suite'
-import {MemoryFileSystem, FileSystem} from "../src/universal";
+import {MemoryFileSystem} from "../src/universal";
 
 describe('the in memory implementation', function() {
     assertFileSystemContract(

--- a/test/timeout-fs.spec.ts
+++ b/test/timeout-fs.spec.ts
@@ -6,14 +6,12 @@ import {
     ignoredFile,
     dirName,
     fileName,
-    content
 } from './implementation-suite'
 import {SlowFs} from '../test-kit/drivers/slow-fs';
 import {MemoryFileSystem, TimeoutFileSystem, FileSystem} from '../src/universal';
 
 describe('the timeout file system imeplementation', () => {
     const timeout = 200;
-    const accuracyFactor = 0.9;
 
     assertFileSystemContract(() =>
         Promise.resolve(new TimeoutFileSystem(timeout , new MemoryFileSystem(undefined, [ignoredDir, ignoredFile]))),
@@ -23,7 +21,6 @@ describe('the timeout file system imeplementation', () => {
     describe(`delayed timeout test`, () => {
         let fs: FileSystem;
         let startTimestamp: number;
-        let endTimestamp: number;
         const delay = timeout * 2;
 
         beforeEach(() => {

--- a/test/wamp-client-fs.spec.ts
+++ b/test/wamp-client-fs.spec.ts
@@ -1,9 +1,8 @@
-import {EventEmitter} from 'eventemitter3';
 import * as Promise from 'bluebird';
 import * as retry from 'bluebird-retry';
 import {expect} from 'chai';
-import {WampServer, WampRouter, wampRealm, wampServerOverFs} from '../src/nodejs';
-import {FileSystem, WampClientFileSystem, MemoryFileSystem} from '../src/universal';
+import {WampServer, wampRealm, wampServerOverFs} from '../src/nodejs';
+import {WampClientFileSystem, MemoryFileSystem} from '../src/universal';
 import {noConnectionError} from '../src/wamp-client-fs';
 import {EventsMatcher} from '../test-kit/drivers/events-matcher';
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,57 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
-    "noImplicitAny": false,
-    "strictNullChecks": true,
-    "stripInternal": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "typeRoots" : ["./node_modules/@types","./custom-typings"]
-  },
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": ["es2015"],                        /* Specify library files to be included in the compilation:  */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                            /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "typeRoots": [
+      "./node_modules/@types",
+      "./custom-typings"
+    ],                                        /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    "inlineSources": true                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
 }


### PR DESCRIPTION
regenerated tsconfig with latest typescript
removed a bunch of dead code and imports
added types where missing
also reordered package.json so deps are before devdeps

closes #24

noImplicitReturns still disabled. warnings will be fixed once moving to native promises and async/await.