### PR TITLE
Remove Bluebird in favor of native Promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 os:
   - linux
-  - osx
+#  - osx
 
 addons:
   firefox: latest

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bundle": "webpack",
     "pretest": "yarn run clean && yarn run build && yarn run bundle",
     "test": "yarn run test:node && yarn run test:browser",
-    "test:node": "mocha --reporter mocha-env-reporter dist/test/nodejs",
+    "test:node": "mocha --reporter mocha-env-reporter --timeout 4000 dist/test/nodejs",
     "test:browser": "karma start --single-run",
     "start": "webpack-dev-server --progress"
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
   "homepage": "https://github.com/wix/kissfs#readme",
   "dependencies": {
     "autobahn": "^17.5.2",
-    "bluebird": "^3.5.0",
-    "bluebird-retry": "^0.11.0",
     "chokidar": "^1.7.0",
     "eventemitter3": "^2.0.3",
     "fs-extra": "^4.0.2",
@@ -42,12 +40,11 @@
     "klaw": "^2.1.0",
     "lodash": "^4.17.4",
     "micromatch": "^2.3.11",
+    "tslib": "^1.7.1",
     "wamp-server": "^0.0.6"
   },
   "devDependencies": {
     "@types/autobahn": "^0.9.37",
-    "@types/bluebird": "^3.5.12",
-    "@types/bluebird-retry": "^0.0.33",
     "@types/chai": "^4.0.4",
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-subset": "^1.3.1",
@@ -73,7 +70,7 @@
     "mocha-env-reporter": "^3.0.0",
     "mocha-loader": "^1.1.1",
     "rimraf": "^2.6.2",
-    "sinon": "^3.3.0",
+    "sinon": "^4.0.0",
     "source-map-support": "^0.4.18",
     "tmp": "^0.0.33",
     "ts-loader": "^2.3.7",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 export const pathSeparator = '/';
 
 export interface FileSystemNode {

--- a/src/cache-fs.ts
+++ b/src/cache-fs.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {
     FileSystem,
     FileSystemNode,

--- a/src/local-fs-crud-only.ts
+++ b/src/local-fs-crud-only.ts
@@ -1,29 +1,9 @@
-import {
-    access as access_,
-    ensureDir as ensureDir_,
-    readFile as readFile_,
-    readdir as readdir_,
-    remove as remove_,
-    rmdir as rmdir_,
-    stat as stat_,
-    writeFile as writeFile_
-} from 'fs-extra';
+import {access, ensureDir, readFile, readdir, remove, rmdir, stat, writeFile} from 'fs-extra';
 import * as walk from 'klaw';
-import * as Promise from 'bluebird';
 import * as path from 'path';
-import {Stats} from 'fs';
 import {Directory, FileSystem, pathSeparator, ShallowDirectory, File} from './api';
 import {getIsIgnored, getPathNodes, InternalEventsEmitter, makeEventsEmitter} from './utils';
 import {MemoryFileSystem} from './memory-fs';
-
-const ensureDir = Promise.promisify<void, string>(ensureDir_);
-const readFile = Promise.promisify<string, string, string>(readFile_);
-const readdir = Promise.promisify<Array<string>, string>(readdir_);
-const writeFile = Promise.promisify<void, string, any>(writeFile_);
-const remove = Promise.promisify<void, string>(remove_ as (dir: string, callback: (err: any, _: void) => void) => void);
-const rmdir = Promise.promisify<void, string>(rmdir_ as (dir: string, callback: (err: any, _: void) => void) => void);
-const stat = Promise.promisify<Stats, string>(stat_);
-const access = Promise.promisify<void, string>(access_);
 
 // TODO extract chokidar watch mechanism to configuration
 export class LocalFileSystemCrudOnly implements FileSystem {
@@ -99,26 +79,29 @@ export class LocalFileSystemCrudOnly implements FileSystem {
         return readFile(path.join(this.baseUrl, relPath), 'utf8');
     }
 
-    loadDirectoryChildren(fullPath:string): Promise<(File | ShallowDirectory)[]> {
+    async loadDirectoryChildren(fullPath: string): Promise<(File | ShallowDirectory)[]> {
         if (this.isIgnored(fullPath)) {
             return Promise.reject(new Error(`Unable to read ignored path: '${fullPath}'`));
         }
         let rootPath = path.join(this.baseUrl, fullPath);
         let pathPrefix = fullPath ? (fullPath + pathSeparator) : fullPath;
-        return Promise.map(readdir(rootPath), (item:string) => {
+        const directoryChildren = await readdir(rootPath);
+
+        const processedChildren = await Promise.all(directoryChildren.map(async item => {
             const itemPath = pathPrefix + item;
             let itemAbsolutePath = path.join(rootPath, item);
-            return stat(itemAbsolutePath).then((s:Stats)=>{
-                if (s.isDirectory()){
-                    return new ShallowDirectory(item, itemPath);
-                } else if (s.isFile()){
-                    return new File(item, itemPath);
-                } else {
-                    console.warn(`unknown node type at ${itemAbsolutePath}`);
-                    return null;
-                }
-            })
-        }).filter<File | ShallowDirectory>((i:File | ShallowDirectory | null)=> i!==null);
+            const itemStatus = await stat(itemAbsolutePath);
+            if (itemStatus.isDirectory()) {
+                return new ShallowDirectory(item, itemPath);
+            } else if (itemStatus.isFile()) {
+                return new File(item, itemPath);
+            } else {
+                console.warn(`Unknown node type at ${itemAbsolutePath}`);
+                return null;
+            }
+        }));
+
+        return processedChildren.filter((i): i is File | Directory => i !== null);
     }
 
     loadDirectoryTree(fullPath: string): Promise<Directory> {
@@ -129,7 +112,7 @@ export class LocalFileSystemCrudOnly implements FileSystem {
         // if fullPath is not empty, memfs will contain a sub-tree of the real FS but the root is the same
         const memFs = new MemoryFileSystem();
 
-        return Promise.fromCallback<Directory>((callback) => {
+        return new Promise<Directory>((resolve, reject) => {
             const {baseUrl, isIgnored} = this;
             const rootPath = fullPath ? path.join(baseUrl, fullPath) : baseUrl;
             const walker = walk(rootPath);
@@ -148,10 +131,10 @@ export class LocalFileSystemCrudOnly implements FileSystem {
                     }
                 }
             })
-            .on('end', function () {
-                callback(null, memFs.loadDirectoryTreeSync(fullPath));
-            })
-            .on('error', callback);
+                .on('end', function () {
+                    resolve(memFs.loadDirectoryTreeSync(fullPath));
+                })
+                .on('error', reject);
         });
     }
 

--- a/src/memory-fs.ts
+++ b/src/memory-fs.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {last, find} from 'lodash';
 import {
     FileSystem,
@@ -48,32 +47,32 @@ export class MemoryFileSystem implements FileSystem {
         return current;
     }
 
-    saveFile(fullPath:string, newContent:string): Promise<void> {
-        return Promise.try(() => this.saveFileSync(fullPath, newContent));
+    async saveFile(fullPath: string, newContent: string): Promise<void> {
+        return this.saveFileSync(fullPath, newContent);
     }
 
-    deleteFile(fullPath:string): Promise<void> {
-        return Promise.try(() => this.deleteFileSync(fullPath));
+    async deleteFile(fullPath: string): Promise<void> {
+        return this.deleteFileSync(fullPath);
     }
 
-    deleteDirectory(fullPath: string, recursive?: boolean): Promise<void> {
-        return Promise.try(() => this.deleteDirectorySync(fullPath, recursive))
+    async deleteDirectory(fullPath: string, recursive?: boolean): Promise<void> {
+        return this.deleteDirectorySync(fullPath, recursive)
     }
 
-    ensureDirectory(fullPath:string):Promise<void> {
-        return Promise.try(() => this.ensureDirectorySync(fullPath));
+    async ensureDirectory(fullPath: string): Promise<void> {
+        return this.ensureDirectorySync(fullPath);
     }
 
-    loadTextFile(fullPath: string): Promise<string> {
-        return Promise.try(() => this.loadTextFileSync(fullPath));
+    async loadTextFile(fullPath: string): Promise<string> {
+        return this.loadTextFileSync(fullPath);
     }
 
-    loadDirectoryTree(fullPath?:string): Promise<Directory> {
-        return Promise.try(() => this.loadDirectoryTreeSync(fullPath));
+    async loadDirectoryTree(fullPath?: string): Promise<Directory> {
+        return this.loadDirectoryTreeSync(fullPath);
     }
 
-    loadDirectoryChildren(fullPath:string): Promise<(File | ShallowDirectory)[]>{
-        return Promise.try(() => this.loadDirectoryChildrenSync(fullPath));
+    async loadDirectoryChildren(fullPath: string): Promise<(File | ShallowDirectory)[]> {
+        return this.loadDirectoryChildrenSync(fullPath);
     }
 
     saveFileSync(fullPath:string, newContent:string): void {

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -19,10 +19,16 @@ export async function retryPromise<T>(promiseProvider: () => Promise<T>, {interv
     let aborted = false;
     let lastError: Error;
     return new Promise<T>(async (resolve, reject) => {
-        timeout && setTimeout(() => {aborted = true; reject(lastError);}, timeout);
+        if (timeout) {
+            setTimeout(() => {
+                aborted = true;
+                reject(lastError);
+            }, timeout);
+        }
         do {
             try {
-                return resolve(await promiseProvider())
+                const result = await promiseProvider();
+                return resolve(result);
             } catch (e) {
                 lastError = e;
                 if (retries > 0) {

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -1,0 +1,35 @@
+export function timeoutPromise<T>(ms: number, promise: Promise<T>, message = `timed out after ${ms}ms`): Promise<T> {
+    return new Promise(function (resolve, reject) {
+        setTimeout(() => reject(new Error(message)), ms);
+        promise.then(resolve).catch(reject);
+    });
+}
+
+export function delayedPromise(delay: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+export interface RetryPromiseOptions {
+    interval: number;
+    retries: number;
+    timeout?: number;
+}
+
+export async function retryPromise<T>(promiseProvider: () => Promise<T>, {interval, retries, timeout}: RetryPromiseOptions): Promise<T> {
+    let aborted = false;
+    let lastError: Error;
+    return new Promise<T>(async (resolve, reject) => {
+        timeout && setTimeout(() => {aborted = true; reject(lastError);}, timeout);
+        do {
+            try {
+                return resolve(await promiseProvider())
+            } catch (e) {
+                lastError = e;
+                if (retries > 0) {
+                    await delayedPromise(interval);
+                }
+            }
+        } while (!aborted && retries-- > 0);
+        reject(lastError);
+    })
+}

--- a/src/timeout-fs.ts
+++ b/src/timeout-fs.ts
@@ -5,8 +5,7 @@ import {
     EventEmitter,
     isDisposable, ShallowDirectory
 } from './api';
-
-import * as Promise from 'bluebird';
+import { timeoutPromise } from './promise-utils';
 
 export class TimeoutFileSystem implements FileSystem{
     constructor(private timeout: number, private fs: FileSystem) {}
@@ -20,31 +19,31 @@ export class TimeoutFileSystem implements FileSystem{
     }
 
     saveFile(fullPath:string, newContent:string): Promise<void>{
-        return this.fs.saveFile(fullPath , newContent).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.saveFile(fullPath , newContent));
     }
 
     deleteFile(fullPath:string):Promise<void>{
-        return this.fs.deleteFile(fullPath).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.deleteFile(fullPath));
     }
 
     deleteDirectory(fullPath:string, recursive?:boolean):Promise<void>{
-        return this.fs.deleteDirectory(fullPath , recursive).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.deleteDirectory(fullPath , recursive));
     }
 
     loadTextFile(fullPath:string): Promise<string>{
-        return this.fs.loadTextFile(fullPath).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.loadTextFile(fullPath));
     }
 
     loadDirectoryTree(fullPath?:string): Promise<Directory>{
-        return this.fs.loadDirectoryTree(fullPath).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.loadDirectoryTree(fullPath));
     }
 
     loadDirectoryChildren(fullPath:string): Promise<(File | ShallowDirectory)[]> {
-        return this.fs.loadDirectoryChildren(fullPath).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.loadDirectoryChildren(fullPath));
     }
 
     ensureDirectory(fullPath:string): Promise<void>{
-        return this.fs.ensureDirectory(fullPath).timeout(this.timeout);
+        return timeoutPromise(this.timeout, this.fs.ensureDirectory(fullPath));
     }
 
     dispose() {

--- a/src/wamp-server-over-fs.ts
+++ b/src/wamp-server-over-fs.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {Connection, Session} from 'autobahn';
 import {FileSystem, fileSystemEventNames, fileSystemMethods, isDisposable} from './api';
 import {wampRealm, wampRealmPrefix} from './constants';

--- a/test-kit/drivers/events-matcher.ts
+++ b/test-kit/drivers/events-matcher.ts
@@ -1,7 +1,6 @@
-import {expect} from "chai";
-import * as Promise from 'bluebird';
-import * as retry from 'bluebird-retry';
+import {expect} from 'chai';
 import {EventEmitter} from 'eventemitter3';
+import {delayedPromise, retryPromise} from '../../src/promise-utils';
 
 export interface EventObj{
     type:string;
@@ -25,34 +24,24 @@ export class EventsMatcher{
         }))
     }
 
-    private expectEvents(events: Array<EventObj>):Promise<void>{
+    async expect(events: Array<EventObj>):Promise<void>{
+        await this.expectEvents(events)
+        
+        await delayedPromise(this.options.noExtraEventsGrace);
+        expect(this.events, 'no further events after matching').to.eql([]);
+    }
+
+    private async expectEvents(events: Array<EventObj>):Promise<void>{
+        const {interval, timeout} = this.options;
         if (events.length) {
-            return retry(this.checkEvents.bind(this, events), this.options)
-                .then(() => undefined)
-                .catch(e => {
-                    throw e.failure;
-                });
+            await retryPromise(() => this.checkEvents(events), {retries: 100, interval, timeout});
         } else {
             expect(this.events).to.eql([]);
-            return Promise.resolve();
         }
     }
 
-    expect(events: Array<EventObj>):Promise<void>{
-        return this.expectEvents(events)
-                .delay(this.options.noExtraEventsGrace)
-                .then(() => {
-                    expect(this.events, 'no further events after matching').to.eql([]);
-                });
-    }
-
-    private checkEvents(events: Array<EventObj>){
-        try {
-            expect(this.events).to.containSubset(events);
-            this.events = [];
-            return Promise.resolve();
-        } catch(e){
-            return Promise.reject(e);
-        }
+    private async checkEvents(events: Array<EventObj>): Promise<void> {
+        expect(this.events).to.containSubset(events);
+        this.events = [];
     }
 }

--- a/test-kit/drivers/events-matcher.ts
+++ b/test-kit/drivers/events-matcher.ts
@@ -25,19 +25,15 @@ export class EventsMatcher{
     }
 
     async expect(events: Array<EventObj>):Promise<void>{
-        await this.expectEvents(events)
-        
-        await delayedPromise(this.options.noExtraEventsGrace);
-        expect(this.events, 'no further events after matching').to.eql([]);
-    }
-
-    private async expectEvents(events: Array<EventObj>):Promise<void>{
         const {interval, timeout} = this.options;
         if (events.length) {
             await retryPromise(() => this.checkEvents(events), {retries: 100, interval, timeout});
         } else {
             expect(this.events).to.eql([]);
         }
+        
+        await delayedPromise(this.options.noExtraEventsGrace);
+        expect(this.events, 'no further events after matching').to.eql([]);
     }
 
     private async checkEvents(events: Array<EventObj>): Promise<void> {

--- a/test-kit/drivers/slow-fs.ts
+++ b/test-kit/drivers/slow-fs.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {
     FileSystem,
     Directory,
@@ -6,9 +5,10 @@ import {
     isDisposable, ShallowDirectory
 } from "../../src/api";
 
-import {MemoryFileSystem} from "../../src/memory-fs";
-import {InternalEventsEmitter} from "../../src/utils";
-import {ignoredDir, ignoredFile} from "../../test/implementation-suite";
+import {MemoryFileSystem} from '../../src/memory-fs';
+import {InternalEventsEmitter} from '../../src/utils';
+import {ignoredDir, ignoredFile} from '../../test/implementation-suite';
+import {delayedPromise} from '../../src/promise-utils';
 
 export class SlowFs implements FileSystem {
     public readonly events: InternalEventsEmitter;
@@ -21,31 +21,31 @@ export class SlowFs implements FileSystem {
     }
 
     saveFile(fullPath:string, newContent:string):Promise<void> {
-        return Promise.delay(this.delay).then(() => this.fs.saveFile(fullPath, newContent));
+        return delayedPromise(this.delay).then(() => this.fs.saveFile(fullPath, newContent));
     }
 
     deleteFile(fullPath:string):Promise<void> {
-        return Promise.delay(this.delay).then(() => this.fs.deleteFile(fullPath));
+        return delayedPromise(this.delay).then(() => this.fs.deleteFile(fullPath));
     }
 
     deleteDirectory(fullPath: string, recursive: boolean = false): Promise<void> {
-        return Promise.delay(this.delay).then(() => this.fs.deleteDirectory(fullPath, recursive));
+        return delayedPromise(this.delay).then(() => this.fs.deleteDirectory(fullPath, recursive));
     }
 
     ensureDirectory(fullPath:string): Promise<void> {
-        return Promise.delay(this.delay).then(() => this.fs.ensureDirectory(fullPath));
+        return delayedPromise(this.delay).then(() => this.fs.ensureDirectory(fullPath));
     }
 
     loadTextFile(fullPath:string): Promise<string>{
-        return Promise.delay(this.delay).then(() => this.fs.loadTextFile(fullPath));
+        return delayedPromise(this.delay).then(() => this.fs.loadTextFile(fullPath));
     }
 
     loadDirectoryTree(fullPath?:string): Promise<Directory> {
-        return Promise.delay(this.delay).then(() => this.fs.loadDirectoryTree(fullPath));
+        return delayedPromise(this.delay).then(() => this.fs.loadDirectoryTree(fullPath));
     }
 
     loadDirectoryChildren(fullPath:string): Promise<(File | ShallowDirectory)[]> {
-        return Promise.delay(this.delay).then(() => this.fs.loadDirectoryChildren(fullPath));
+        return delayedPromise(this.delay).then(() => this.fs.loadDirectoryChildren(fullPath));
     }
 
     dispose() {

--- a/test-kit/index.ts
+++ b/test-kit/index.ts
@@ -1,9 +1,6 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import chaiSubset = require('chai-subset');
-import * as Promise from 'bluebird';
-
-Promise.longStackTraces();
 
 chai.use(chaiSubset);
 chai.use(chaiAsPromised);

--- a/test-kit/test/slow-fs.spec.ts
+++ b/test-kit/test/slow-fs.spec.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {expect} from 'chai';
 import {FileSystem} from '../../src/api';
 import {

--- a/test/cache-fs.spec.ts
+++ b/test/cache-fs.spec.ts
@@ -1,6 +1,5 @@
 import {EventEmitter} from 'eventemitter3';
 import {InternalEventsEmitter} from '../src/utils';
-import * as Promise from 'bluebird';
 import {expect} from 'chai';
 import {EventsMatcher} from '../test-kit/drivers/events-matcher';
 import {SlowFs} from '../test-kit/drivers/slow-fs';

--- a/test/implementation-suite.ts
+++ b/test/implementation-suite.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai";
 import {FileSystem, fileSystemEventNames, pathSeparator} from '../src/universal';
 import {EventsMatcher} from '../test-kit/drivers/events-matcher';
-import * as Promise from 'bluebird';
 import {EventEmitter} from 'eventemitter3';
 
 

--- a/test/implementation-suite.ts
+++ b/test/implementation-suite.ts
@@ -46,7 +46,6 @@ export function assertFileSystemContract(fsProvider: () => Promise<FileSystem>, 
         });
 
         it(`ensuring existence of directory`, function() {
-            const dirName = fileName;
             const expectedStructure = {
                 type:'dir', name:'', fullPath:'', children:[
                     {type:'dir', name:dirName, fullPath:dirName, children:[]}

--- a/test/local-fs.spec.ts
+++ b/test/local-fs.spec.ts
@@ -65,7 +65,7 @@ describe(`the local filesystem implementation`, () => {
     const eventMatcherOptions: EventsMatcher.Options = {
         interval: 50,
         noExtraEventsGrace: 150,
-        timeout: 1500
+        timeout: 3000
     };
     assertFileSystemContract(getFS, eventMatcherOptions);
     describe(`external changes`, () => {

--- a/test/local-fs.spec.ts
+++ b/test/local-fs.spec.ts
@@ -9,7 +9,6 @@ import {
 
 import {join} from 'path';
 import {expect} from 'chai';
-import * as Promise from 'bluebird';
 import {EventEmitter} from 'eventemitter3';
 
 import {

--- a/test/memory-fs.spec.ts
+++ b/test/memory-fs.spec.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {assertFileSystemContract, ignoredDir, ignoredFile} from './implementation-suite'
 import {MemoryFileSystem} from "../src/universal";
 

--- a/test/timeout-fs.spec.ts
+++ b/test/timeout-fs.spec.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import {expect} from 'chai';
 import {
     assertFileSystemContract,

--- a/test/wamp-client-fs.spec.ts
+++ b/test/wamp-client-fs.spec.ts
@@ -1,6 +1,5 @@
-import * as Promise from 'bluebird';
-import * as retry from 'bluebird-retry';
 import {expect} from 'chai';
+import {retryPromise} from '../src/promise-utils';
 import {WampServer, wampRealm, wampServerOverFs} from '../src/nodejs';
 import {WampClientFileSystem, MemoryFileSystem} from '../src/universal';
 import {noConnectionError} from '../src/wamp-client-fs';
@@ -42,9 +41,9 @@ describe(`the wamp client filesystem implementation`, () => {
         return new Promise(resolve => {
             wampServer.router.close();
             const errMsg = `WAMP connection hasn't been closed after the previous test`;
-            return retry(
+            return retryPromise(
                 () => (wampServer.connection as any).isConnected ? Promise.reject(errMsg) : Promise.resolve(),
-                {interval: 100, max_tries: 10}
+                {interval: 100, retries: 10}
             ).then(() => resolve())
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    "importHelpers": true,                    /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,41 +1,51 @@
-var path = require('path');
+const path = require('path');
 
-var NODE_MODULES_PATH = path.resolve(__dirname, 'node_modules');
-
-var loaders = {
-    loaders: [
-        {
-            test: /\.ts[x]?$/,
-            exclude : NODE_MODULES_PATH,
-            loader: 'ts-loader?logLevel=warn' // &transpileOnly=true
-        }
-    ],
-    noParse: /\.min\.js$/
-};
-
-var resolve = {
-    extensions: ['.ts', '.js'],
-    alias: {
-        'bluebird-retry': 'bluebird-retry/lib/bluebird-retry'
-    }
-};
-
-var output = {
-    path: __dirname + '/dist',
-    filename: '[name].bundle.js',
-    libraryTarget: 'umd',
-    library: '[name]',
-    pathinfo: true
-};
+const NODE_MODULES_PATH = path.resolve(__dirname, 'node_modules');
+const polyfills = ['core-js/es6/symbol', 'core-js/es6/number', 'core-js/es6/promise'];
 
 module.exports = {
     context: __dirname,
     entry: {
-        test: ['./test/browser'],
-        webtest: ['mocha-loader!./test/browser']
+        test: polyfills.concat(['./test/browser']),
+        webtest: polyfills.concat(['mocha-loader!./test/browser'])
     },
     devtool: 'eval',
-    output: output,
-    resolve: resolve,
-    module: loaders
+    module: {
+        rules: [
+            {
+                test: /\.ts[x]?$/,
+                loader: 'ts-loader',
+                exclude : NODE_MODULES_PATH,
+                options: {
+                    compilerOptions: {
+                        'declaration': false
+                    }
+                }
+            },        
+            {
+                test: /\.js$/,
+                include: [
+                    path.resolve(__dirname, 'node_modules/chai-as-promised'),
+                    path.resolve(__dirname, 'node_modules/cbor')
+                ],
+                loader: 'ts-loader',
+                options: {
+                    // needed so it has a separate transpilation instance
+                    instance: 'lib-compat',
+                    transpileOnly: true
+                }
+            }
+        ],
+        noParse: /\.min\.js$/
+    },
+    output: {
+        path: __dirname + '/dist',
+        filename: '[name].bundle.js',
+        libraryTarget: 'umd',
+        library: '[name]',
+        pathinfo: true
+    },
+    resolve: {
+        extensions: ['.ts', '.js']
+    }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,16 +8,6 @@
   dependencies:
     "@types/when" "*"
 
-"@types/bluebird-retry@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/bluebird-retry/-/bluebird-retry-0.0.33.tgz#e8fffbd8bad91f67c0f8be1b5f75a073eed148fd"
-  dependencies:
-    "@types/bluebird" "*"
-
-"@types/bluebird@*", "@types/bluebird@^3.5.12":
-  version "3.5.12"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.12.tgz#180881847ff664e9e294a5dcdcd4c8e9a150e5a7"
-
 "@types/chai-as-promised@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz#010b04cde78eacfb6e72bfddb3e58fe23c2e78b9"
@@ -210,6 +200,10 @@ arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -294,10 +288,6 @@ async@^2.1.2:
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
-
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -403,11 +393,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird-retry@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.11.0.tgz#1289ab22cbbc3a02587baad35595351dd0c1c047"
-
-bluebird@^3.3.0, bluebird@^3.5.0:
+bluebird@^3.3.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
@@ -558,21 +544,6 @@ buffer@^4.3.0:
     bindings "~1.2.1"
     nan "~2.4.0"
 
-build@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/build/-/build-0.1.4.tgz#707fe026ffceddcacbfdcdf356eafda64f151046"
-  dependencies:
-    cssmin "0.3.x"
-    jsmin "1.x"
-    jxLoader "*"
-    moo-server "*"
-    promised-io "*"
-    timespan "2.x"
-    uglify-js "1.x"
-    walker "1.x"
-    winston "*"
-    wrench "1.3.x"
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -589,9 +560,20 @@ callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
 
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  dependencies:
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -770,10 +752,6 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
-
-colors@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
 colors@^1.1.0, colors@~1.1.2:
   version "1.1.2"
@@ -993,10 +971,6 @@ cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
-cssmin@0.3.x:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/cssmin/-/cssmin-0.3.2.tgz#ddce4c547b510ae0d594a8f1fbf8aaf8e2c5c00d"
-
 "cssnano@>=2.6.1 <4":
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
@@ -1041,13 +1015,15 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  dependencies:
+    array-find-index "^1.0.1"
+
 custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
-
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
 d@1:
   version "1.0.0"
@@ -1106,13 +1082,6 @@ deep-equal@^1.0.1:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-
-default-gateway@^2.2.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-2.5.0.tgz#78e24dbd2e1df7490c2b8050515b8e816bfa7da5"
-  dependencies:
-    execa "^0.7.0"
-    ip-regex "^2.1.0"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -1543,10 +1512,6 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
@@ -1716,6 +1681,10 @@ get-caller-file@^1.0.1:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
+get-stdin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1956,6 +1925,12 @@ ieee754@^1.1.4, ieee754@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -1987,12 +1962,11 @@ ini@~1.3.0:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
 
-internal-ip@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-2.0.3.tgz#ed3cf9b671ac7ff23037bfacad42eb439cd9546c"
+internal-ip@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-1.2.0.tgz#ae9fbf93b984878785d50a8de1b356956058cf5c"
   dependencies:
-    default-gateway "^2.2.2"
-    ipaddr.js "^1.5.2"
+    meow "^3.3.0"
 
 interpret@^1.0.0:
   version "1.0.4"
@@ -2002,10 +1976,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -2013,10 +1983,6 @@ ip@^1.1.0, ip@^1.1.5:
 ipaddr.js@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.4.0.tgz#296aca878a821816e5b85d0a285a99bcff4582f0"
-
-ipaddr.js@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -2071,6 +2037,12 @@ is-extglob@^1.0.0:
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -2198,17 +2170,13 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isstream@0.1.x, isstream@~0.1.2:
+isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 js-base64@^2.1.9:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.2.tgz#a79a923666372b580f8e27f51845c6f7e8fbfbaf"
-
-js-yaml@0.3.x:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-0.3.7.tgz#d739d8ee86461e54b354d6a7d7d1f2ad9a167f62"
 
 js-yaml@~3.7.0:
   version "3.7.0"
@@ -2224,10 +2192,6 @@ jsbn@~0.1.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
-
-jsmin@1.x:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
 
 json-loader@^0.5.4:
   version "0.5.7"
@@ -2287,15 +2251,6 @@ jsprim@^1.2.2:
 just-extend@^1.1.22:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
-
-jxLoader@*:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jxLoader/-/jxLoader-0.1.1.tgz#0134ea5144e533b594fc1ff25ff194e235c53ecd"
-  dependencies:
-    js-yaml "0.3.x"
-    moo-server "1.3.x"
-    promised-io "*"
-    walker "1.x"
 
 karma-chrome-launcher@^2.2.0:
   version "2.2.0"
@@ -2557,6 +2512,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
 lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
@@ -2572,11 +2534,9 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
-makeerror@1.0.x:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
-  dependencies:
-    tmpl "1.0.x"
+map-obj@^1.0.0, map-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -2605,6 +2565,21 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+meow@^3.3.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  dependencies:
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -2679,7 +2654,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2722,10 +2697,6 @@ mocha@^3.5.3:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
-
-moo-server@*, moo-server@1.3.x:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/moo-server/-/moo-server-1.3.0.tgz#5dc79569565a10d6efed5439491e69d2392e58f1"
 
 ms@0.7.1:
   version "0.7.1"
@@ -2775,7 +2746,7 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-nise@^1.0.1:
+nise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.1.0.tgz#37e41b9bf0041ccb83d1bf03e79440bbc0db10ad"
   dependencies:
@@ -2843,7 +2814,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3426,10 +3397,6 @@ process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-promised-io@*:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/promised-io/-/promised-io-0.3.5.tgz#4ad217bb3658bcaae9946b17a8668ecd851e1356"
-
 proxy-addr@~1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
@@ -3605,6 +3572,13 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  dependencies:
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
+
 reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
@@ -3662,6 +3636,12 @@ repeat-string@^0.2.2:
 repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  dependencies:
+    is-finite "^1.0.0"
 
 request@2.81.0:
   version "2.81.0"
@@ -3833,17 +3813,16 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-3.3.0.tgz#9132111b4bbe13c749c2848210864250165069b1"
+sinon@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.0.0.tgz#a54a5f0237aa1dd2215e5e81c89b42b50c4fdb6b"
   dependencies:
-    build "^0.1.4"
     diff "^3.1.0"
     formatio "1.2.0"
     lodash.get "^4.4.2"
     lolex "^2.1.2"
     native-promise-only "^0.8.1"
-    nise "^1.0.1"
+    nise "^1.1.0"
     path-to-regexp "^1.7.0"
     samsam "^1.1.3"
     text-encoding "0.6.4"
@@ -3996,10 +3975,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -4079,6 +4054,12 @@ strip-bom@^3.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  dependencies:
+    get-stdin "^4.0.1"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -4167,10 +4148,6 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
-timespan@2.x:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
-
 tmp@0.0.31, tmp@0.0.x:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
@@ -4182,10 +4159,6 @@ tmp@^0.0.33:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
     os-tmpdir "~1.0.2"
-
-tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
 to-array@0.1.4:
   version "0.1.4"
@@ -4201,6 +4174,10 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
 ts-loader@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
@@ -4209,6 +4186,10 @@ ts-loader@^2.3.7:
     enhanced-resolve "^3.0.0"
     loader-utils "^1.0.2"
     semver "^5.0.1"
+
+tslib@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -4242,10 +4223,6 @@ type-is@~1.6.15:
 typescript@~2.5.2:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
-
-uglify-js@1.x:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-1.3.5.tgz#4b5bfff9186effbaa888e4c9e94bd9fc4c94929d"
 
 uglify-js@^2.8.29:
   version "2.8.29"
@@ -4396,12 +4373,6 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
-walker@1.x:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
-  dependencies:
-    makeerror "1.0.x"
-
 wamp-server@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/wamp-server/-/wamp-server-0.0.6.tgz#0949844f5906a8785e42088907249df0780218ce"
@@ -4434,8 +4405,8 @@ webpack-dev-middleware@^1.11.0:
     time-stamp "^2.0.0"
 
 webpack-dev-server@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.8.2.tgz#abd61f410778cc4c843d7cebbf41465b1ab7734c"
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz#7ac9320b61b00eb65b2109f15c82747fc5b93585"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -4447,7 +4418,7 @@ webpack-dev-server@^2.8.2:
     express "^4.13.3"
     html-entities "^1.2.0"
     http-proxy-middleware "~0.17.4"
-    internal-ip "^2.0.2"
+    internal-ip "1.2.0"
     ip "^1.1.5"
     loglevel "^1.4.1"
     opn "^5.1.0"
@@ -4539,17 +4510,6 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-winston@*:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.1.tgz#0b48420d978c01804cf0230b648861598225a119"
-  dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    stack-trace "0.0.x"
-
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
@@ -4568,10 +4528,6 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-wrench@1.3.x:
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/wrench/-/wrench-1.3.9.tgz#6f13ec35145317eb292ca5f6531391b244111411"
 
 ws@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR should fix the "Core3 Regular Test".

- got rid of bluebird and bluebird-retry
- implemented three promise utils for delay, timeout, and retry
- webpack doesn't generate .d.ts in ts-loader
- transpiles chai-as-promised and cbor using a separate ts-loader instance (for es5 compat)
- load symbol, promise, and es6 number polyfills during tests
- coverted several functions to async/await (especially where bluebird was used)