### PR TITLE
retryPromise: improve flow and avoid bad pattern

### DIFF
--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -28,7 +28,8 @@ export function retryPromise<T>(
     let lastError: Error;
     const timeoutReject = timeout && delayedPromise(timeout).then(() => Promise.reject(uniqueObj));
 
-    async function tryRun(retriesLeft: number, shouldDelay: boolean): Promise<T> {
+    async function tryRun(retriesLeft: number): Promise<T> {
+        const shouldDelay = interval && retriesLeft !== retries; // first run is not delayed
         try {
             if (timeoutReject) {
                 shouldDelay && await Promise.race([delayedPromise(interval), timeoutReject]);
@@ -41,12 +42,12 @@ export function retryPromise<T>(
             if (e !== uniqueObj) { // only retry if not a timeout
                 lastError = e;
                 if (retriesLeft) {
-                    return tryRun(retriesLeft - 1, true);
+                    return tryRun(retriesLeft - 1);
                 }
             }
             throw lastError || new Error(timeoutMessage);
         }
     }
 
-    return tryRun(retries, false); // first run is not delayed
+    return tryRun(retries);
 }

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -24,7 +24,7 @@ export async function retryPromise<T>(
     if (timeout && timeout <= retries * interval) {
         throw new Error(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`);
     }
-    let lastError: Error = new Error(timeoutMessage);
+    let lastError: Error | undefined;
     let retriesLeft = retries;
     const timeoutReject = timeout && delayedPromise(timeout).then(() => Promise.reject(uniqueObj));
     do {
@@ -40,6 +40,7 @@ export async function retryPromise<T>(
         } catch (e) {
             if (e === uniqueObj) { // only retry if not a timeout
                 retriesLeft = 0;
+                lastError = lastError || new Error(timeoutMessage);
             } else {
                 lastError = e;
             }

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -22,7 +22,7 @@ export async function retryPromise<T>(
     promiseProvider: () => Promise<T>,
     {interval, retries, timeout, timeoutMessage = `timed out after ${timeout}ms`}: RetryPromiseOptions): Promise<T> {
     if (timeout && timeout <= retries * interval) {
-        return Promise.reject(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`)
+        throw new Error(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`);
     }
     let lastError: Error = new Error(timeoutMessage);
     let retriesLeft = retries;

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -22,7 +22,7 @@ export function retryPromise<T>(
     promiseProvider: () => Promise<T>,
     {interval, retries, timeout, timeoutMessage = `timed out after ${timeout}ms`}: RetryPromiseOptions): Promise<T> {
 
-        if (timeout && timeout <= retries * interval) {
+    if (timeout && timeout <= retries * interval) {
         return Promise.reject(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`)
     }
     let lastError: Error;

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -16,7 +16,7 @@ export interface RetryPromiseOptions {
     timeoutMessage?: string;
 }
 
-const uniqueObj = {}; // used to identify timeout in retryPromise
+const timeoutSymbol = Symbol('timeout');
 
 export async function retryPromise<T>(
     promiseProvider: () => Promise<T>,
@@ -25,24 +25,24 @@ export async function retryPromise<T>(
         throw new Error(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`);
     }
     let lastError: Error | undefined;
-    const timeoutReject = timeout && delayedPromise(timeout).then(() => Promise.reject(uniqueObj));
+    const timeoutPromise = timeout && delayedPromise(timeout).then(() => timeoutSymbol);
     do {
         const shouldDelay = interval && lastError !== undefined;
         try {
-            if (timeoutReject) {
-                shouldDelay && await Promise.race([delayedPromise(interval), timeoutReject]);
-                return await Promise.race([promiseProvider(), timeoutReject])
+            if (timeoutPromise) {
+                shouldDelay && await Promise.race([delayedPromise(interval), timeoutPromise]);
+                const result = await Promise.race([promiseProvider(), timeoutPromise])
+                if (result === timeoutSymbol) {
+                    lastError = lastError || new Error(timeoutMessage);
+                    break;
+                }
+                return result as T;
             } else {
                 shouldDelay && await delayedPromise(interval);
                 return await promiseProvider();
             }
         } catch (e) {
-            if (e === uniqueObj) { // only retry if not a timeout
-                retries = 0;
-                lastError = lastError || new Error(timeoutMessage);
-            } else {
-                lastError = e;
-            }
+            lastError = e;
         }
     } while (retries-- > 0);
     throw lastError;

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -21,7 +21,6 @@ const uniqueObj = {}; // used to identify timeout in retryPromise
 export function retryPromise<T>(
     promiseProvider: () => Promise<T>,
     {interval, retries, timeout, timeoutMessage = `timed out after ${timeout}ms`}: RetryPromiseOptions): Promise<T> {
-
     if (timeout && timeout <= retries * interval) {
         return Promise.reject(`timeout (${timeout}ms) must be greater than retries (${retries}) times interval (${interval}ms)`)
     }


### PR DESCRIPTION
No longer creates an empty Promise without any use (`async (resolve, reject)=>...`).
No longer checks and rechecks whether it's in a timout.
When timeout value is provided, it creates a single delayed rejected promise and uses it with Promise.race when doing operations.
A unique object is used to identify a timeout error. First try was `class TimeoutError extends Error {}`, but `instanceof TimeoutError` is false for IE11/Edge.