### PR TITLE
Correct tests not cleaning up after themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chai-subset": "^1.6.0",
     "cross-var": "^1.1.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "mocha-env-reporter": "^3.0.0",
     "mocha-headless-chrome": "^2.0.1",
     "mocha-loader": "^2.0.0",
@@ -77,7 +77,7 @@
     "typescript": "~3.0.3",
     "typescript-support": "^0.5.4",
     "wait-on": "^3.0.1",
-    "webpack": "^4.18.0",
+    "webpack": "^4.18.1",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.8"
   }

--- a/test/local-fs.spec.node.ts
+++ b/test/local-fs.spec.node.ts
@@ -27,10 +27,6 @@ const fileSystemOptions: LocalFileSystem.Options = {
 };
 
 
-function writeFileToDisk(path: string, content: string) {
-    writeFileSync(path, content);
-}
-
 describe(`the local filesystem implementation`, () => {
     let dirCleanup: () => void;
     let rootPath: string;
@@ -97,13 +93,13 @@ describe(`the local filesystem implementation`, () => {
 
             it(`handles file creation`, () => {
                 const path = join(testPath, fileName);
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 return expect(fs.loadTextFile(fileName)).to.eventually.equals(content);
             });
 
             it(`handles file deletion`, () => {
                 const path = join(testPath, fileName);
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 unlinkSync(path);
                 return expect(fs.loadTextFile(fileName)).to.eventually.be.rejected;
             });
@@ -111,9 +107,9 @@ describe(`the local filesystem implementation`, () => {
             it(`handles file change`, async () => {
                 const path = join(testPath, fileName);
                 const newContent = `_${content}`;
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 await matcher.expect([{type: 'fileCreated', fullPath: fileName, newContent: content}]);
-                writeFileToDisk(path, newContent);
+                writeFileSync(path, newContent);
                 expect(await fs.loadTextFile(fileName)).to.equal(newContent);
             });
         });
@@ -122,7 +118,7 @@ describe(`the local filesystem implementation`, () => {
             it(`emits 'unexpectedError' if 'loadTextFile' rejected in watcher 'add' callback`, () => {
                 fs.loadTextFile = () => Promise.reject('go away!');
                 const path = join(testPath, fileName);
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 return matcher.expect([{type: 'unexpectedError'}]);
             });
 
@@ -162,20 +158,20 @@ describe(`the local filesystem implementation`, () => {
             });
             it('should dispatch events for empty files', async () => {
                 const path = join(testPath, fileName);
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 await matcher.expect([{type: 'fileCreated', fullPath: fileName, newContent: content}]);
 
-                writeFileToDisk(path, '');
+                writeFileSync(path, '');
                 await matcher.expect([{type: 'fileChanged', fullPath: fileName, newContent: ''}]);
             });
             it('should not dispatch events for empty files if another change is detected within buffer time', async () => {
                 const path = join(testPath, fileName);
-                writeFileToDisk(path, content);
+                writeFileSync(path, content);
                 await matcher.expect([{type: 'fileCreated', fullPath: fileName, newContent: content}]);
 
-                writeFileToDisk(path, '');
+                writeFileSync(path, '');
                 await matcher.expect([]);
-                writeFileToDisk(path, 'gaga');
+                writeFileSync(path, 'gaga');
                 await matcher.expect([{type: 'fileChanged', fullPath: fileName, newContent: 'gaga'}]);
 
             });

--- a/test/wamp-client-fs.spec.node.ts
+++ b/test/wamp-client-fs.spec.node.ts
@@ -1,12 +1,12 @@
-import {expect} from 'chai';
-import {retryPromise} from '../src/promise-utils';
-import {wampRealm, WampServer, wampServerOverFs} from '../src/nodejs';
-import {MemoryFileSystem, WampClientFileSystem} from '../src/universal';
-import {noConnectionError} from '../src/wamp-client-fs';
-import {EventsMatcher} from './events-matcher';
-import {assertFileSystemContract} from './implementation-suite'
-import {fileSystemAsyncMethods} from "../src/api";
-import {spy} from 'sinon';
+import { expect } from 'chai';
+import { retryPromise } from '../src/promise-utils';
+import { wampRealm, WampServer, wampServerOverFs } from '../src/nodejs';
+import { MemoryFileSystem, WampClientFileSystem } from '../src/universal';
+import { noConnectionError } from '../src/wamp-client-fs';
+import { EventsMatcher } from './events-matcher';
+import { assertFileSystemContract } from './implementation-suite'
+import { fileSystemAsyncMethods } from "../src/api";
+import { spy } from 'sinon';
 
 const msg = 'foo';
 const fakeArgs = ['foo', 'bar'];
@@ -20,12 +20,13 @@ describe(`the wamp client filesystem proxy`, () => {
         return wampServerOverFs(underlyingFs, 3000);
     }
 
-    function getFS(): Promise<WampClientFileSystem> {
-        return Promise.resolve(new WampClientFileSystem(`ws://127.0.0.1:3000`, wampRealm));
+    async function getFS(): Promise<WampClientFileSystem> {
+        return new WampClientFileSystem(`ws://127.0.0.1:3000`, wampRealm);
     }
 
-    function getInitedFS(): Promise<WampClientFileSystem> {
-        return getFS().then(fs => fs.init());
+    async function getInitedFS(): Promise<WampClientFileSystem> {
+        const fs = await getFS();
+        return fs.init();
     }
 
     const eventMatcherOptions: EventsMatcher.Options = {
@@ -35,32 +36,45 @@ describe(`the wamp client filesystem proxy`, () => {
         timeout: 1500
     };
 
-    beforeEach(() => server().then(clientAndServer => wampServer = clientAndServer));
+    beforeEach(async () => {
+        wampServer = await server();
+    });
 
     afterEach(() => {
         wampServer.router.close();
         const errMsg = `WAMP connection hasn't been closed after the previous test`;
         return retryPromise(
             () => (wampServer.connection as any).isConnected ? Promise.reject(errMsg) : Promise.resolve(),
-            {interval: 100, retries: 10}
+            { interval: 100, retries: 10 }
         );
     });
 
     fileSystemAsyncMethods.forEach(asyncMethodName => {
         describe(`${asyncMethodName} method`, () => {
-            it(`fails when not inited`, () => {
-                return expect(getFS().then(fs => (fs[asyncMethodName] as Function)(...fakeArgs))).to.eventually.be.rejectedWith(noConnectionError);
+            let fs: WampClientFileSystem | undefined
+
+            afterEach(() => {
+                if (fs) {
+                    fs.dispose();
+                }
             });
+
+            it(`fails when not inited`, async () => {
+                const withoutInit = await getFS()
+                return expect((withoutInit[asyncMethodName] as Function)(...fakeArgs)).to.eventually.be.rejectedWith(noConnectionError);
+            });
+
             it(`passes arguments and results correctly`, async () => {
-                const fs = await getInitedFS();
+                fs = await getInitedFS();
                 let methodImpl = spy(async () => msg);
                 (underlyingFs as any)[asyncMethodName] = methodImpl;
                 const res = await (fs[asyncMethodName] as Function)(...fakeArgs);
                 expect(res).to.eql(msg);
                 expect(methodImpl).to.have.been.calledWith(...fakeArgs);
             });
+
             it(`reports original error messages`, async () => {
-                const fs = await getInitedFS();
+                fs = await getInitedFS();
                 (underlyingFs as any)[asyncMethodName] = async () => {
                     throw new Error(msg)
                 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,8 +15,10 @@
     samsam "1.3.0"
 
 "@sinonjs/samsam@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  dependencies:
+    array-from "^2.1.1"
 
 "@types/autobahn@^0.9.39":
   version "0.9.39"
@@ -378,6 +380,10 @@ array-flatten@1.1.1:
 array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -1187,9 +1193,9 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
@@ -1476,11 +1482,9 @@ combined-stream@1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0:
-  version "2.9.0"
-  resolved "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+commander@2.15.1:
+  version "2.15.1"
+  resolved "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@^2.16.0:
   version "2.18.0"
@@ -1717,12 +1721,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1853,11 +1851,7 @@ detect-node@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
 
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-
-diff@^3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -2392,14 +2386,14 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+glob@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2436,13 +2430,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -2464,10 +2454,6 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3010,7 +2996,7 @@ json-text-sequence@^0.1:
   dependencies:
     delimit-stream "0.1.0"
 
-json3@3.3.2, json3@^3.3.2:
+json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
@@ -3122,40 +3108,9 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -3164,22 +3119,6 @@ lodash.debounce@^4.0.8:
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.keys@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
 
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
@@ -3281,7 +3220,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -3336,7 +3275,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3412,22 +3351,21 @@ mocha-loader@^2.0.0:
     script-loader "^0.7.2"
     style-loader "^0.22.1"
 
-mocha@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
     escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
+    glob "7.1.2"
+    growl "1.10.5"
     he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
+    minimatch "3.0.4"
     mkdirp "0.5.1"
-    supports-color "3.1.2"
+    supports-color "5.4.0"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -4161,13 +4099,12 @@ read-pkg@^3.0.0:
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
   dependencies:
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
     readable-stream "^2.0.2"
-    set-immediate-shim "^1.0.1"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -4440,10 +4377,6 @@ serve-static@1.13.2:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-
-set-immediate-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
 set-value@^0.4.3:
   version "0.4.3"
@@ -4799,11 +4732,11 @@ style-loader@^0.22.1:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
-    has-flag "^1.0.0"
+    has-flag "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -4815,7 +4748,7 @@ supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-co
   dependencies:
     has-flag "^3.0.0"
 
-tapable@^1.0.0:
+tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.0.tgz#0d076a172e3d9ba088fd2272b2668fb8d194b78c"
 
@@ -5224,9 +5157,9 @@ webpack-sources@^1.1.0, webpack-sources@^1.2.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.18.0:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.18.0.tgz#7dafaaf309c12e63080d3960fba7ed94afdcbe84"
+webpack@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.18.1.tgz#029042c815443fce23424de1548d9317cfca148a"
   dependencies:
     "@webassemblyjs/ast" "1.7.6"
     "@webassemblyjs/helper-module-context" "1.7.6"
@@ -5248,7 +5181,7 @@ webpack@^4.18.0:
     neo-async "^2.5.0"
     node-libs-browser "^2.0.0"
     schema-utils "^0.4.4"
-    tapable "^1.0.0"
+    tapable "^1.1.0"
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
     webpack-sources "^1.2.0"


### PR DESCRIPTION
- newer `mocha` versions hanged for `kissfs` due to tests not properly disposing watcher and wamp server. this is now fixed, and `mocha` was upgraded to latest version :)
- upgraded to `webpack@4.18.1` along the way
- removed unneeded `writeFileToDisk` function in local-fs.spec.node.ts